### PR TITLE
Update interactive options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Options:
   Enter a number to select a command
   r - Regenerate suggestions
   c - Add a comment or clarification
-  0 or empty - Quit
+  q, 0 or empty - Quit
 
 Your choice:
 ```


### PR DESCRIPTION
## Summary
- fix quit option in README interactive instructions

## Testing
- `python3 main.py --help` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `python3 -m py_compile main.py utils.py model.py install.py`