### PR TITLE
Add missing type hints

### DIFF
--- a/install.py
+++ b/install.py
@@ -7,22 +7,22 @@ PROJECT_DIR = Path(__file__).resolve().parent
 HOME = Path.home()
 SHELL_RC = HOME / '.bashrc'
 
-def run(cmd):
+def run(cmd: str) -> None:
     print(f"$ {cmd}")
     subprocess.run(cmd, shell=True, check=True)
 
-def ensure_uv():
+def ensure_uv() -> None:
     try:
         run('uv --version')
     except subprocess.CalledProcessError:
         print('Installing uv package manager...')
         run('pip install --upgrade uv')
 
-def install_deps():
+def install_deps() -> None:
     run("uv venv")
     run(f'cd {PROJECT_DIR} && uv pip install -r requirements.txt')
 
-def link_commands():
+def link_commands() -> None:
     cmd_file = PROJECT_DIR / "commands.sh"
     source_line = f"source {cmd_file}\n"
 
@@ -33,7 +33,7 @@ def link_commands():
     else:
         print("Source line already present.")
 
-def create_env():
+def create_env() -> None:
     example = PROJECT_DIR / ".env.example"
     target  = PROJECT_DIR / ".env"
 
@@ -47,7 +47,7 @@ def create_env():
     else:
         print("Warning: .env.example missing; skipping .env creation.")
 
-def create_context_script():
+def create_context_script() -> None:
     target = PROJECT_DIR / ".aih_context.sh"
     
     if target.exists():
@@ -59,7 +59,7 @@ def create_context_script():
     target.chmod(0o755)
     print("Created empty .aih_context.sh file.")
     
-def main():
+def main() -> None:
     ensure_uv()
     install_deps()
     link_commands()

--- a/main.py
+++ b/main.py
@@ -60,10 +60,16 @@ def parse_args() -> argparse.Namespace:
 
 class ChoiceResult:
     """Result from the choose function with different possible actions."""
-    def __init__(self, cmd=None, action=None, comment=None):
-        self.cmd = cmd  # Selected command
-        self.action = action  # 'execute', 'regenerate', 'comment'
-        self.comment = comment  # User comment if action is 'comment'
+
+    def __init__(
+        self,
+        cmd: Optional[str] = None,
+        action: Optional[str] = None,
+        comment: Optional[str] = None,
+    ) -> None:
+        self.cmd: Optional[str] = cmd  # Selected command
+        self.action: Optional[str] = action  # 'execute', 'regenerate', 'comment'
+        self.comment: Optional[str] = comment  # User comment if action is 'comment'
 
 
 def display_suggestions(suggestions: List[str]) -> None:
@@ -124,7 +130,11 @@ def confirm(cmd: str) -> bool:
     return ans in {"y", "yes"}
 
 
-def build_full_context(args, prev_suggestions: List[str] = None, user_comment: str = None) -> Optional[str]:
+def build_full_context(
+    args: argparse.Namespace,
+    prev_suggestions: Optional[List[str]] = None,
+    user_comment: Optional[str] = None,
+) -> Optional[str]:
     """Build the full context including commands.md, environment context, and user feedback."""
     # Get commands.md content regardless of context flag
     cmd_md_path = PROJECT_DIR / "commands.md"

--- a/utils.py
+++ b/utils.py
@@ -6,11 +6,11 @@ import threading
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, MutableMapping, Iterator
 
 from dotenv import load_dotenv
 
-def load_env(env_path: Optional[str] = None):
+def load_env(env_path: Optional[str] = None) -> MutableMapping[str, str]:
     """Load .env file and return a mapping of env vars."""
     env_path = env_path or Path(__file__).with_name('.env')
     load_dotenv(env_path)
@@ -58,7 +58,7 @@ def build_context() -> str:
 
 
 @contextmanager
-def spinner(msg: str = "Loading..."):
+def spinner(msg: str = "Loading...") -> Iterator[None]:
     """Simple terminal spinner context manager."""
     stop = False
 


### PR DESCRIPTION
## Summary
- type `load_env` and `spinner` helpers
- type installation helper functions
- improve typing for `ChoiceResult` and context building

## Testing
- `python -m py_compile $(git ls-files '*.py')`